### PR TITLE
Support both cashu A and cashu B

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -109,7 +109,7 @@ export const URL_PATTERN = /(https?:\/\/+[^\s"'<`\]]+[^\s"'<`:\.]+)/g;
 
 export const LN_URL_PATTERN = /lnurl1[02-9ac-hj-np-z]+/gi;
 export const LNBC_PATTERN = /lnbc[0-9]*[munp]?1[02-9ac-hj-np-z]+/gi;
-export const CASHU_TOKEN_PATTERN = /cashuA[A-Za-z0-9_-]+=*/g;
+export const CASHU_TOKEN_PATTERN = /cashu[AB][A-Za-z0-9_-]+=*/g;
 export const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 export const CUSTOM_EMOJI_PATTERN = /:([a-zA-Z0-9_+-]+):/g;
 export const HASHTAG_PATTERN =


### PR DESCRIPTION
There are two types of cashu tokens, cashu A and cashu B. I don't know what the difference is, but it should handle both.

---

cashuにはAとBの2種類がある。違いはよく知らないけど、どっちも使うできるはずだと思います。